### PR TITLE
Liens vers présentation

### DIFF
--- a/presentations/Semaine8/CarlThibault/README.md
+++ b/presentations/Semaine8/CarlThibault/README.md
@@ -2,8 +2,11 @@
 
 Un examen de l'incident "npm left-pad" et des leçons qu'on peut en tirer.
 
+#### Liens vers la présentation
 
-##### Bibliographie préliminaire:
+https://udemontreal-my.sharepoint.com/:f:/g/personal/carl_thibault_umontreal_ca/EjBQVQa01OpDqMkKwtz-I3QB9oLRJmq4nwvtXW-SijMLyA?e=wBGS57
+
+##### Bibliographie:
 
 https://dl.acm.org/doi/10.1145/3347446
 
@@ -14,5 +17,3 @@ https://lwn.net/Articles/681410/
 https://blog.npmjs.org/post/141577284765/kik-left-pad-and-npm
 
 https://azerkoculu.com/posts/left-pad
-
-https://www.youtube.com/watch?v=SHv4DYXKunY


### PR DESCRIPTION
Ajout d'un lien onedrive vers la présentation au format PDF, celle-ci pourrait être modifiée d'ici le cours du 31 octobre, mais le liens restera le même.